### PR TITLE
fix(log): generate a map API Key and use https only resources to prevent mixed content

### DIFF
--- a/data/hoverboard.config.json
+++ b/data/hoverboard.config.json
@@ -25,7 +25,7 @@
         "indexedDbSession": "hoverboard"
     },
     "mailchimp": {
-        "url": "http://eepurl.com/b6Pgvn",
+        "url": "https://eepurl.com/b6Pgvn",
         "name": "Recevoir la newsletter"
     },
     "dateFormat": {
@@ -69,7 +69,7 @@
         "url": "https://www.linkedin.com/company/10254434"
     }],
     "location": {
-        "apiKey": "",
+        "apiKey": "AIzaSyAsYarycfx4sV9QhauT5li-63snSTqoJ3g",
         "name": "Cinéma CGR Blagnac",
         "address": "E.Leclerc Blagnac, ZAC du Grand Noble, 2 Allée Emile Zola, 31700 Blagnac",
         "link": "http://www.cgrcinemas.fr/blagnac/",


### PR DESCRIPTION
The Map API Key have been restricted to domain *.devfesttoulouse.fr and devfesttoulouse.fr

We are waiting the validation from @JulienDelRio about MailChimp url in HTTPS (which should be valid, but I prefer double check 😉 